### PR TITLE
junit: XML escape fully removes ANSI sequences

### DIFF
--- a/libexec/bats-core/bats-format-junit
+++ b/libexec/bats-core/bats-format-junit
@@ -103,9 +103,9 @@ xml_escape() {
   output=${output//>/\&gt;}
   output=${output//'"'/\&quot;}
   output=${output//\'/\&#39;}
-  # remove ANSI Color codes
+  # remove ANSI escape sequences (e.g. color codes, clearing terminal)
   local CONTROL_CHAR=$'\033'
-  local REGEX="$CONTROL_CHAR\[[0-9;]+m"
+  local REGEX="$CONTROL_CHAR\[[0-9;]*[a-zA-Z]"
   while [[ "$output" =~ $REGEX ]]; do
       output=${output//${BASH_REMATCH[0]}/}
   done


### PR DESCRIPTION
Previously, ANSI sequences like '\033[H\033[J' (e.g. clearing terminal) broke XML output and tests.

Added removal of full ANSI escape codes to fix this issue.

fixes #896

- [x] I have reviewed the [Contributor Guidelines][contributor].
- [x] I have reviewed the [Code of Conduct][coc] and agree to abide by it

[contributor]: https://github.com/bats-core/bats-core/blob/master/docs/CONTRIBUTING.md
[coc]:         https://github.com/bats-core/bats-core/blob/master/docs/CODE_OF_CONDUCT.md
